### PR TITLE
docs: update course links to official DesignGurus.io

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -2,7 +2,7 @@
 
 ## Origin of the Content
 
-This website is based on the "Grokking the Object Oriented Design Interview" course from [Educative.io](https://www.educative.io/courses/grokking-the-object-oriented-design-interview), enhanced with additional code examples and improved navigation.
+This website is based on the "Grokking the Object Oriented Design Interview" course from [DesignGurus.io](https://www.designgurus.io/course/grokking-the-object-oriented-design-interview), enhanced with additional code examples and improved navigation.
 
 The original repository contains:
 
@@ -38,7 +38,7 @@ If you find any issues or have suggestions for improvement, please feel free to 
 
 Special thanks to:
 
-- **Educative.io** for the original course content
+- **DesignGurus.io** for the original course content
 - **Contributors** who have helped enhance the material
 - **The open-source community** for providing the tools used to build this site
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,4 +35,4 @@ Choose a section to begin your learning journey:
 
 ## About This Guide
 
-This website is based on the original content from the [Grokking the Object Oriented Design Interview](https://www.educative.io/courses/grokking-the-object-oriented-design-interview) course from Educative.io, enhanced with additional code examples.
+This website is based on the original content from the [Grokking the Object Oriented Design Interview](https://www.designgurus.io/course/grokking-the-object-oriented-design-interview) course from DesignGurus.io, enhanced with additional code examples.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Grokking the Object Oriented Design Interview
 site_description: A comprehensive guide to object-oriented design interviews
-site_author: Original content from educative.io
-copyright: "Original content from educative.io"
+site_author: Original content from designgurus.io
+copyright: "Original content from designgurus.io"
 site_url: https://noblenihal.github.io/Grokking-the-Object-Oriented-Design-Interview
 
 theme:

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 <h1 align="center">Grokking the Object Oriented Design Interview</h1>
 
-I create this repository as extended version of [Grokking the Object Oriented Design Interview](https://www.educative.io/courses/grokking-the-object-oriented-design-interview) course. I add `example-codes` part for better understanding.
+I create this repository as extended version of [Grokking the Object Oriented Design Interview](https://www.designgurus.io/course/grokking-the-object-oriented-design-interview) course. I add `example-codes` part for better understanding.
 
 ### **Notes:**
 
@@ -75,7 +75,7 @@ View diagrams using [PlantUML Online Editor](http://www.plantuml.com/plantuml/um
 <h3 align="center">** Sources **</h3>
 <hr />
 <p align="center">
-    <b>Course Source: <b/></b><a href="https://www.educative.io/courses/grokking-the-object-oriented-design-interview"><b>Grokking the Object Oriented Design Interview</b></a>
+    <b>Course Source: <b/></b><a href="https://www.designgurus.io/course/grokking-the-object-oriented-design-interview"><b>Grokking the Object Oriented Design Interview</b></a>
     <br />
     <b>Banner Photo Source: <b/></b><a href="https://dribbble.com"><b>Dribbble</b></a>
 </p>


### PR DESCRIPTION
The original authors have migrated the course to DesignGurus.io. Updating these references to point to the official, most up-to-date version and ensure proper attribution.