### PR TITLE
Fix: Mark BankAccount as abstract in ATM UML diagram

### DIFF
--- a/object-diagram.puml
+++ b/object-diagram.puml
@@ -399,7 +399,7 @@ package "ATM System" #Lavender {
         + addATM(atm)
     }
     
-    class BankAccount {
+    abstract class BankAccount {
         - accountNumber: string
         - totalBalance: double
         - availableBalance: double


### PR DESCRIPTION
The ATM UML diagram currently represents BankAccount as a concrete class. However, the implementation defines BankAccount as an abstract class, so the diagram does not accurately reflect the design. This PR updates the ATM UML notation to mark BankAccount as abstract.

Fixes https://github.com/tssovi/grokking-the-object-oriented-design-interview/issues/51